### PR TITLE
Fix tremendous lag from dropped item entitites

### DIFF
--- a/src/main/java/twilightforest/TFTickHandler.java
+++ b/src/main/java/twilightforest/TFTickHandler.java
@@ -188,6 +188,7 @@ public class TFTickHandler {
                                 if (this.playerDroppedEntityItem != null) {
                                     this.playerDroppedEntityItem.triggerAchievement(TFAchievementPage.twilightPortal);
                                 }
+                                this.setDead();
                             }
                         }
                     }

--- a/src/main/java/twilightforest/TFTickHandler.java
+++ b/src/main/java/twilightforest/TFTickHandler.java
@@ -40,7 +40,11 @@ import cpw.mods.fml.common.network.internal.FMLProxyPacket;
  */
 public class TFTickHandler {
 
-    public Item portalItem = null;
+    private final Item portalItem;
+
+    public TFTickHandler(Item portalItemIn) {
+        this.portalItem = portalItemIn;
+    }
 
     /**
      * On the tick, we check for eligible portals

--- a/src/main/java/twilightforest/TFTickHandler.java
+++ b/src/main/java/twilightforest/TFTickHandler.java
@@ -1,8 +1,5 @@
 package twilightforest;
 
-import static twilightforest.block.BlockTFPortal.isGoodPortalPool;
-
-import java.util.List;
 import java.util.Random;
 
 import net.minecraft.block.material.Material;
@@ -10,11 +7,8 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.MathHelper;
-import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraft.world.gen.structure.StructureBoundingBox;
@@ -25,7 +19,6 @@ import twilightforest.block.BlockTFPortal;
 import twilightforest.block.TFBlocks;
 import twilightforest.world.ChunkProviderTwilightForest;
 import twilightforest.world.WorldProviderTwilightForest;
-import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
 import cpw.mods.fml.common.gameevent.TickEvent.PlayerTickEvent;
@@ -54,34 +47,6 @@ public class TFTickHandler {
 
         EntityPlayer player = event.player;
         World world = player.worldObj;
-
-        // check for portal creation, at least if it's not disabled
-        if (!TwilightForestMod.disablePortalCreation && event.phase == TickEvent.Phase.END
-                && !world.isRemote
-                && world.getTotalWorldTime() % 20 == 0) {
-            // skip non admin players when the option is on
-            if (TwilightForestMod.adminOnlyPortals) {
-                try {
-                    // if
-                    // (MinecraftServer.getServer().getConfigurationManager().isPlayerOpped(player.getCommandSenderName().toString()))
-                    // {
-                    if (MinecraftServer.getServer().getConfigurationManager().func_152596_g(player.getGameProfile())) {
-                        // reduce range to 4.0 when the option is on
-                        checkForPortalCreation(player, world, 4.0F);
-
-                    }
-                } catch (NoSuchMethodError ex) {
-                    // stop checking admin
-                    FMLLog.warning(
-                            "[TwilightForest] Could not determine op status for adminOnlyPortals option, ignoring option.");
-                    TwilightForestMod.adminOnlyPortals = false;
-                }
-            } else {
-                // normal check, no special options
-                checkForPortalCreation(player, world, 32.0F);
-
-            }
-        }
 
         // check the player for being in a forbidden progression area, only every 20 ticks
         if (!world.isRemote && event.phase == TickEvent.Phase.END
@@ -149,75 +114,6 @@ public class TFTickHandler {
         }
     }
 
-    @SubscribeEvent
-    public void tickStart(ItemTossEvent event) {
-        FMLLog.fine("[TwilightForest] ItemTossEvent Tick");
-    }
-
-    private void checkForPortalCreation(EntityPlayer player, World world, float rangeToCheck) {
-        // make sure we are allowed to make a portal in this dimension
-        if (world != null && player != null
-                && (world.provider.dimensionId == 0 || world.provider.dimensionId == TwilightForestMod.dimensionID
-                        || TwilightForestMod.allowPortalsInOtherDimensions)) {
-            @SuppressWarnings("unchecked")
-            List<EntityItem> itemList = world.getEntitiesWithinAABB(
-                    EntityItem.class,
-                    player.boundingBox.expand(rangeToCheck, rangeToCheck, rangeToCheck));
-
-            // do we have the item set? if not, can we set it?
-            if (this.portalItem == null) {
-
-            }
-
-            // check to see if someone's thrown the portal item into the water
-            for (EntityItem entityItem : itemList) {
-                int dx = MathHelper.floor_double(entityItem.posX);
-                int dy = MathHelper.floor_double(entityItem.posY);
-                int dz = MathHelper.floor_double(entityItem.posZ);
-                if (entityItem.getEntityItem().getItem() == portalItem
-                        && world.isMaterialInBB(entityItem.boundingBox, Material.water)) {
-                    // make sparkles in the area
-                    Random rand = new Random();
-                    for (int k = 0; k < 2; k++) {
-                        double d = rand.nextGaussian() * 0.02D;
-                        double d1 = rand.nextGaussian() * 0.02D;
-                        double d2 = rand.nextGaussian() * 0.02D;
-
-                        world.spawnParticle(
-                                "spell",
-                                entityItem.posX,
-                                entityItem.posY + 0.2,
-                                entityItem.posZ,
-                                d,
-                                d1,
-                                d2);
-                    }
-
-                    // try to make a portal
-                    if (((BlockTFPortal) TFBlocks.portal).tryToCreatePortal(world, dx, dy, dz)) {
-                        player.triggerAchievement(TFAchievementPage.twilightPortal);
-                        return;
-                    }
-                }
-            }
-            for (EntityItem entityItem : itemList) {
-                int dx = MathHelper.floor_double(entityItem.posX);
-                int dy = MathHelper.floor_double(entityItem.posY);
-                int dz = MathHelper.floor_double(entityItem.posZ);
-                if (isGoodPortalPool(world, dx, dy, dz) && entityItem.age < 20) {
-                    if (player instanceof EntityPlayerMP) {
-                        player.addChatComponentMessage(
-                                new ChatComponentText(
-                                        String.format(
-                                                StatCollector.translateToLocal("chat.tf.wrongportalitem"),
-                                                portalItem.getItemStackDisplayName(new ItemStack(portalItem)))));
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
     /**
      * Check what biome the player is in, and see if current progression allows that biome. If not, take appropriate
      * action
@@ -235,4 +131,69 @@ public class TFTickHandler {
             }
         }
     }
+
+    @SubscribeEvent
+    public void onItemDroppedByPlayer(ItemTossEvent event) {
+        if (!TwilightForestMod.disablePortalCreation && !event.isCanceled()
+                && this.portalItem != null
+                && event.entityItem.getEntityItem().getItem() == this.portalItem) {
+            // Check if player is opped
+            if (TwilightForestMod.adminOnlyPortals && !MinecraftServer.getServer().getConfigurationManager()
+                    .func_152596_g(event.player.getGameProfile())) {
+                return;
+            }
+            event.player.joinEntityItemWithWorld(new PortalEntityItem(event.entityItem, event.player));
+            event.setCanceled(true);
+        }
+    }
+
+    private static class PortalEntityItem extends EntityItem {
+
+        // the player that dropped this portal item
+        private final EntityPlayer playerDroppedEntityItem;
+
+        public PortalEntityItem(EntityItem entityItemToReplace, EntityPlayer player) {
+            super(
+                    entityItemToReplace.worldObj,
+                    entityItemToReplace.posX,
+                    entityItemToReplace.posY,
+                    entityItemToReplace.posZ,
+                    entityItemToReplace.getEntityItem());
+            this.delayBeforeCanPickup = entityItemToReplace.delayBeforeCanPickup;
+            this.motionX = entityItemToReplace.motionX;
+            this.motionY = entityItemToReplace.motionY;
+            this.motionZ = entityItemToReplace.motionZ;
+            this.playerDroppedEntityItem = player;
+        }
+
+        @Override
+        public void onUpdate() {
+            if (!this.worldObj.isRemote && this.ticksExisted % 20 == 0) if (this.worldObj.provider.dimensionId == 0
+                    || this.worldObj.provider.dimensionId == TwilightForestMod.dimensionID
+                    || TwilightForestMod.allowPortalsInOtherDimensions) {
+                        if (this.worldObj.isMaterialInBB(this.boundingBox, Material.water)) {
+                            // make sparkles in the area
+                            Random rand = new Random();
+                            for (int k = 0; k < 2; k++) {
+                                double d = rand.nextGaussian() * 0.02D;
+                                double d1 = rand.nextGaussian() * 0.02D;
+                                double d2 = rand.nextGaussian() * 0.02D;
+                                this.worldObj.spawnParticle("spell", this.posX, this.posY + 0.2, this.posZ, d, d1, d2);
+                            }
+                            int dx = MathHelper.floor_double(this.posX);
+                            int dy = MathHelper.floor_double(this.posY);
+                            int dz = MathHelper.floor_double(this.posZ);
+                            // try to make a portal
+                            if (((BlockTFPortal) TFBlocks.portal).tryToCreatePortal(this.worldObj, dx, dy, dz)) {
+                                if (this.playerDroppedEntityItem != null) {
+                                    this.playerDroppedEntityItem.triggerAchievement(TFAchievementPage.twilightPortal);
+                                }
+                            }
+                        }
+                    }
+            super.onUpdate();
+        }
+
+    }
+
 }

--- a/src/main/java/twilightforest/TFTickHandler.java
+++ b/src/main/java/twilightforest/TFTickHandler.java
@@ -1,6 +1,7 @@
 package twilightforest;
 
 import java.util.Random;
+import java.util.UUID;
 
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.item.EntityItem;
@@ -149,8 +150,8 @@ public class TFTickHandler {
 
     private static class PortalEntityItem extends EntityItem {
 
-        // the player that dropped this portal item
-        private final EntityPlayer playerDroppedEntityItem;
+        // the UUID of the player that dropped this portal item
+        private final UUID uuidPlayerWhoDroppedThis;
 
         public PortalEntityItem(EntityItem entityItemToReplace, EntityPlayer player) {
             super(
@@ -163,7 +164,7 @@ public class TFTickHandler {
             this.motionX = entityItemToReplace.motionX;
             this.motionY = entityItemToReplace.motionY;
             this.motionZ = entityItemToReplace.motionZ;
-            this.playerDroppedEntityItem = player;
+            this.uuidPlayerWhoDroppedThis = player.getUniqueID();
         }
 
         @Override
@@ -185,8 +186,10 @@ public class TFTickHandler {
                             int dz = MathHelper.floor_double(this.posZ);
                             // try to make a portal
                             if (((BlockTFPortal) TFBlocks.portal).tryToCreatePortal(this.worldObj, dx, dy, dz)) {
-                                if (this.playerDroppedEntityItem != null) {
-                                    this.playerDroppedEntityItem.triggerAchievement(TFAchievementPage.twilightPortal);
+                                // func_152378_a = getPlayerEntityByUUID
+                                final EntityPlayer player = this.worldObj.func_152378_a(this.uuidPlayerWhoDroppedThis);
+                                if (player != null) {
+                                    player.triggerAchievement(TFAchievementPage.twilightPortal);
                                 }
                                 this.setDead();
                             }

--- a/src/main/java/twilightforest/TwilightForestMod.java
+++ b/src/main/java/twilightforest/TwilightForestMod.java
@@ -277,7 +277,9 @@ public class TwilightForestMod {
             portalItem = Items.diamond;
         }
         // tick listener
-        FMLCommonHandler.instance().bus().register(new TFTickHandler(portalItem));
+        final TFTickHandler tfTickHandler = new TFTickHandler(portalItem);
+        MinecraftForge.EVENT_BUS.register(tfTickHandler);
+        FMLCommonHandler.instance().bus().register(tfTickHandler);
 
         // make some channels for our maps
         TFMapPacketHandler mapPacketHandler = new TFMapPacketHandler();

--- a/src/main/java/twilightforest/TwilightForestMod.java
+++ b/src/main/java/twilightforest/TwilightForestMod.java
@@ -199,8 +199,6 @@ public class TwilightForestMod {
     public static boolean hasBiomeIdConflicts = false;
     public static boolean hasAssignedBiomeID = false;
 
-    public static final TFEventListener eventListener = new TFEventListener();
-    public static final TFTickHandler tickHandler = new TFTickHandler();
     public static FMLEventChannel genericChannel;
 
     @Instance(ID)
@@ -258,11 +256,9 @@ public class TwilightForestMod {
         NetworkRegistry.INSTANCE.registerGuiHandler(instance, proxy);
 
         // event listener, for those events that seem worth listening to
+        final TFEventListener eventListener = new TFEventListener();
         MinecraftForge.EVENT_BUS.register(eventListener);
         FMLCommonHandler.instance().bus().register(eventListener); // we're getting events off this bus too
-
-        // tick listener
-        FMLCommonHandler.instance().bus().register(tickHandler);
 
         // set up portal item
         Item portalItem;
@@ -280,7 +276,8 @@ public class TwilightForestMod {
                     portalCreationItemString);
             portalItem = Items.diamond;
         }
-        tickHandler.portalItem = portalItem;
+        // tick listener
+        FMLCommonHandler.instance().bus().register(new TFTickHandler(portalItem));
 
         // make some channels for our maps
         TFMapPacketHandler mapPacketHandler = new TFMapPacketHandler();

--- a/src/main/java/twilightforest/block/BlockTFPortal.java
+++ b/src/main/java/twilightforest/block/BlockTFPortal.java
@@ -82,9 +82,7 @@ public class BlockTFPortal extends BlockBreakable {
     public boolean tryToCreatePortal(World world, int dx, int dy, int dz) {
         if (isGoodPortalPool(world, dx, dy, dz)) {
             world.addWeatherEffect(new EntityLightningBolt(world, dx, dy, dz));
-
             transmuteWaterToPortal(world, dx, dy, dz);
-
             return true;
         } else {
             return false;


### PR DESCRIPTION
Before, to check and create a twilight forest portal, the mod was checking on every second all the dropped items around a player in a 32 blocks radius and for each item, it was checking if it was surrounded by a valid portal like structure. This caused a huge amount of lag quickly bringing the server TPS to 0 as soon as you reach a certain amount of dropped entities.

![image](https://user-images.githubusercontent.com/57050655/222616511-ddbc0491-4d79-4e84-a1b3-bd1e14614f14.png)


Now what I did is the following :
![image](https://user-images.githubusercontent.com/57050655/222615902-a762babd-6c74-4e7d-af1a-c20c8e908686.png)

When a player drops an item, if this item is the portal creation item, the dropped item entity is replaced by a special ticking item entity. This item entity will check if it is dropped in water and if it is surrounded by a valid portal structure.
This way the ticking will only happen for one item and only when the player drops that special portal item.