### PR TITLE
Fix hardcoded world height.

### DIFF
--- a/src/main/java/twilightforest/world/TFGenCanopyMushroom.java
+++ b/src/main/java/twilightforest/world/TFGenCanopyMushroom.java
@@ -45,7 +45,7 @@ public class TFGenCanopyMushroom extends TFTreeGenerator {
         // check if we're on dirt or grass
         Block blockUnder = world.getBlock(x, y - 1, z);
         if (blockUnder != Blocks.grass && blockUnder != Blocks.dirt && blockUnder != Blocks.mycelium
-                || y >= 256 - treeHeight - 1) {
+                || y >= world.getHeight() - treeHeight - 1) {
             return false;
         }
 

--- a/src/main/java/twilightforest/world/TFGenCanopyOak.java
+++ b/src/main/java/twilightforest/world/TFGenCanopyOak.java
@@ -33,7 +33,7 @@ public class TFGenCanopyOak extends TFGenCanopyTree {
 
         // check if we're on dirt or grass
         Material materialUnder = world.getBlock(x, y - 1, z).getMaterial();
-        if ((materialUnder != Material.grass && materialUnder != Material.ground) || y >= TFWorld.MAXHEIGHT - 12) {
+        if ((materialUnder != Material.grass && materialUnder != Material.ground) || y >= world.getHeight() - 12) {
             return false;
         }
 

--- a/src/main/java/twilightforest/world/TFGenCanopyTree.java
+++ b/src/main/java/twilightforest/world/TFGenCanopyTree.java
@@ -43,7 +43,7 @@ public class TFGenCanopyTree extends TFTreeGenerator {
 
         // check if we're on dirt or grass
         Material materialUnder = world.getBlock(x, y - 1, z).getMaterial();
-        if ((materialUnder != Material.grass && materialUnder != Material.ground) || y >= TFWorld.MAXHEIGHT - 12) {
+        if ((materialUnder != Material.grass && materialUnder != Material.ground) || y >= world.getHeight() - 12) {
             return false;
         }
 

--- a/src/main/java/twilightforest/world/TFGenLargeWinter.java
+++ b/src/main/java/twilightforest/world/TFGenLargeWinter.java
@@ -40,7 +40,7 @@ public class TFGenLargeWinter extends TFTreeGenerator {
 
         // check if we're on dirt or grass
         Block blockUnder = world.getBlock(x, y - 1, z);
-        if (blockUnder != Blocks.grass && blockUnder != Blocks.dirt || y >= TFWorld.MAXHEIGHT - treeHeight) {
+        if (blockUnder != Blocks.grass && blockUnder != Blocks.dirt || y >= world.getHeight() - treeHeight) {
             return false;
         }
 

--- a/src/main/java/twilightforest/world/TFGenMangroveTree.java
+++ b/src/main/java/twilightforest/world/TFGenMangroveTree.java
@@ -34,7 +34,7 @@ public class TFGenMangroveTree extends TFTreeGenerator {
     @Override
     public boolean generate(World world, Random random, int x, int y, int z) {
         // we only start over water
-        if ((this.checkForWater && world.getBlock(x, y - 1, z) != Blocks.water) || y >= 128 - 18 - 1) {
+        if ((this.checkForWater && world.getBlock(x, y - 1, z) != Blocks.water) || y >= world.getHeight() - 18 - 1) {
             return false;
         }
 

--- a/src/main/java/twilightforest/world/TFGenMinersTree.java
+++ b/src/main/java/twilightforest/world/TFGenMinersTree.java
@@ -31,7 +31,7 @@ public class TFGenMinersTree extends TFTreeGenerator {
 
         // check soil
         Material materialUnder = world.getBlock(x, y - 1, z).getMaterial();
-        if ((materialUnder != Material.grass && materialUnder != Material.ground) || y >= TFWorld.MAXHEIGHT - 12) {
+        if ((materialUnder != Material.grass && materialUnder != Material.ground) || y >= world.getHeight() - 12) {
             return false;
         }
 

--- a/src/main/java/twilightforest/world/TFGenSmallTwilightOak.java
+++ b/src/main/java/twilightforest/world/TFGenSmallTwilightOak.java
@@ -35,7 +35,7 @@ public class TFGenSmallTwilightOak extends TFTreeGenerator {
         int height = rand.nextInt(3) + this.minTreeHeight;
         boolean allClear = true;
 
-        if (y >= 1 && y + height + 1 <= 256) {
+        if (y >= 1 && y + height + 1 <= world.getHeight()) {
             int cy;
             byte width;
             int cz;
@@ -77,7 +77,7 @@ public class TFGenSmallTwilightOak extends TFTreeGenerator {
             } else {
                 Block blockUsing = world.getBlock(x, y - 1, z);
 
-                if ((blockUsing == Blocks.grass || blockUsing == Blocks.dirt) && y < 256 - height - 1) {
+                if ((blockUsing == Blocks.grass || blockUsing == Blocks.dirt) && y < world.getHeight() - height - 1) {
                     this.setBlock(world, x, y - 1, z, Blocks.dirt);
                     width = 3;
                     byte var18 = 0;

--- a/src/main/java/twilightforest/world/TFGenSortingTree.java
+++ b/src/main/java/twilightforest/world/TFGenSortingTree.java
@@ -33,7 +33,7 @@ public class TFGenSortingTree extends TFGenerator {
     public boolean generate(World world, Random rand, int x, int y, int z) {
         // check soil
         Material materialUnder = world.getBlock(x, y - 1, z).getMaterial();
-        if ((materialUnder != Material.grass && materialUnder != Material.ground) || y >= TFWorld.MAXHEIGHT - 12) {
+        if ((materialUnder != Material.grass && materialUnder != Material.ground) || y >= world.getHeight() - 12) {
             return false;
         }
 

--- a/src/main/java/twilightforest/world/TFGenTreeOfTime.java
+++ b/src/main/java/twilightforest/world/TFGenTreeOfTime.java
@@ -26,7 +26,7 @@ public class TFGenTreeOfTime extends TFGenHollowTree {
         int diameter = 1;
 
         // do we have enough height?
-        if (y < 1 || y + height + diameter > TFWorld.MAXHEIGHT) {
+        if (y < 1 || y + height + diameter > world.getHeight()) {
             // System.out.println("Failed with hollow tree of height " +
             // height);
             return false;


### PR DESCRIPTION
Quick fix as I just remembered this:

Replaces all hardcoded values of world height in tree generation with a call to `world.getHeight()`. In one case the hardcoded value was incorrect (128); this fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14031.