### PR TITLE
Add TF Worldgen override API

### DIFF
--- a/src/main/java/twilightforest/integration/structures/TFMajorFeatureProvider.java
+++ b/src/main/java/twilightforest/integration/structures/TFMajorFeatureProvider.java
@@ -1,0 +1,16 @@
+package twilightforest.integration.structures;
+
+import java.util.Random;
+
+import net.minecraft.world.World;
+import net.minecraft.world.gen.structure.StructureComponent;
+
+import twilightforest.TFFeature;
+
+/**
+ * Lightweight dependency injection to allow overriding Twilight Forest structure implementations.
+ */
+public interface TFMajorFeatureProvider {
+
+    StructureComponent getComponent(World world, Random rand, TFFeature feature, int x, int y, int z);
+}

--- a/src/main/java/twilightforest/integration/structures/TFMajorFeatureProviders.java
+++ b/src/main/java/twilightforest/integration/structures/TFMajorFeatureProviders.java
@@ -1,0 +1,32 @@
+package twilightforest.integration.structures;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import net.minecraft.world.World;
+import net.minecraft.world.gen.structure.StructureComponent;
+
+import twilightforest.TFFeature;
+
+public class TFMajorFeatureProviders {
+
+    private static final List<TFMajorFeatureProvider> providers = new ArrayList<>();
+
+    private TFMajorFeatureProviders() {}
+
+    public static void addProvider(TFMajorFeatureProvider provider) {
+        providers.add(provider);
+    }
+
+    public static StructureComponent getTFMajorFeature(World world, Random rand, TFFeature feature, int x, int y,
+            int z) {
+        for (TFMajorFeatureProvider provider : providers) {
+            StructureComponent tfMajorFeature = provider.getComponent(world, rand, feature, x, y, z);
+            if (tfMajorFeature != null) {
+                return tfMajorFeature;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/twilightforest/integration/structures/TFMajorFeatureProviders.java
+++ b/src/main/java/twilightforest/integration/structures/TFMajorFeatureProviders.java
@@ -21,8 +21,8 @@ public class TFMajorFeatureProviders {
 
     public static StructureComponent getTFMajorFeature(World world, Random rand, TFFeature feature, int x, int y,
             int z) {
-        for (TFMajorFeatureProvider provider : providers) {
-            StructureComponent tfMajorFeature = provider.getComponent(world, rand, feature, x, y, z);
+        for (int i = 0; i < providers.size(); i++) {
+            StructureComponent tfMajorFeature = providers.get(i).getComponent(world, rand, feature, x, y, z);
             if (tfMajorFeature != null) {
                 return tfMajorFeature;
             }

--- a/src/main/java/twilightforest/item/ItemTFMagicMap.java
+++ b/src/main/java/twilightforest/item/ItemTFMagicMap.java
@@ -66,9 +66,9 @@ public class ItemTFMagicMap extends ItemMap {
     }
 
     public void updateMapData(World world, Entity entity, TFMagicMapData mapData) {
-        if (world.provider.dimensionId == mapData.dimension && entity instanceof EntityPlayer) {
-            ChunkProviderTwilightForest chunkProvider = ((WorldProviderTwilightForest) world.provider)
-                    .getChunkProvider();
+        if (world.provider.dimensionId == mapData.dimension && entity instanceof EntityPlayer player
+                && world.provider instanceof WorldProviderTwilightForest tfProvider) {
+            ChunkProviderTwilightForest chunkProvider = tfProvider.getChunkProvider();
             short xSize = 128;
             short zSize = 128;
             int scaleFactor = 1 << mapData.scale;
@@ -79,7 +79,7 @@ public class ItemTFMagicMap extends ItemMap {
             int drawSize = 512 / scaleFactor;
             // int drawSize = 1024 / scaleFactor;
 
-            MapInfo mapInfo = mapData.func_82568_a((EntityPlayer) entity);
+            MapInfo mapInfo = mapData.func_82568_a(player);
             ++mapInfo.field_82569_d;
 
             for (int xStep = xDraw - drawSize + 1; xStep < xDraw + drawSize; ++xStep) {

--- a/src/main/java/twilightforest/structures/ComponentTFHollowHill.java
+++ b/src/main/java/twilightforest/structures/ComponentTFHollowHill.java
@@ -166,9 +166,17 @@ public class ComponentTFHollowHill extends StructureTFComponent {
             Random stalRNG = new Random(world.getSeed() + dx * dz);
 
             // make the actual stalactite
-            TFGenCaveStalactite stalag = TFGenCaveStalactite.makeRandomOreStalactite(stalRNG, hillSize);
+            TFGenCaveStalactite stalag = makeRandomOreStalactite(stalRNG);
             stalag.generate(world, stalRNG, dx, dy, dz);
         }
+    }
+
+    protected int getHillSize() {
+        return hillSize;
+    }
+
+    protected TFGenCaveStalactite makeRandomOreStalactite(Random stalRNG) {
+        return TFGenCaveStalactite.makeRandomOreStalactite(stalRNG, hillSize);
     }
 
     /**

--- a/src/main/java/twilightforest/structures/StructureTFMajorFeatureStart.java
+++ b/src/main/java/twilightforest/structures/StructureTFMajorFeatureStart.java
@@ -17,6 +17,7 @@ import net.minecraft.world.gen.structure.StructureStrongholdPieces;
 import twilightforest.TFFeature;
 import twilightforest.biomes.TFBiomeBase;
 import twilightforest.block.TFBlocks;
+import twilightforest.integration.structures.TFMajorFeatureProviders;
 import twilightforest.structures.courtyard.ComponentTFNagaCourtyardMain;
 import twilightforest.structures.courtyard.TFNagaCourtyardPieces;
 import twilightforest.structures.darktower.ComponentTFDarkTowerMain;
@@ -127,6 +128,11 @@ public class StructureTFMajorFeatureStart extends StructureStart {
      * @return The first component we should add to our structure
      */
     public StructureComponent makeFirstComponent(World world, Random rand, TFFeature feature, int x, int y, int z) {
+
+        StructureComponent componentOverride = TFMajorFeatureProviders.getTFMajorFeature(world, rand, feature, x, y, z);
+        if (componentOverride != null) {
+            return componentOverride;
+        }
 
         if (feature == TFFeature.nagaCourtyard) {
             // return new ComponentTFNagaCourtyard(world, rand, 0, x, y, z);

--- a/src/main/java/twilightforest/world/TFGenCaveStalactite.java
+++ b/src/main/java/twilightforest/world/TFGenCaveStalactite.java
@@ -180,12 +180,16 @@ public class TFGenCaveStalactite extends TFGenerator {
                 }
 
                 for (int dy = 0; dy != (spikeLength * dir); dy += dir) {
-                    setBlock(world, x + dx, y + dy, z + dz, blockID);
+                    placeStalactiteBlock(world, x + dx, y + dy, z + dz);
                 }
             }
         }
 
         return true;
+    }
+
+    protected void placeStalactiteBlock(World world, int x, int y, int z) {
+        setBlock(world, x, y, z, blockID);
     }
 
 }


### PR DESCRIPTION
The intent is to allow the core mod (or any other mod) to specify which ores should be in the stalactites by providing a method to place that stalactite's blocks.

This is an alternative to the method used in #36.

![image](https://github.com/GTNewHorizons/twilightforest/assets/5321549/daf767fa-bb1b-444c-8241-41c17258059d)
![image](https://github.com/GTNewHorizons/twilightforest/assets/5321549/f82d9905-037a-46a4-a7fa-af2bedd6e9ad)


Thanks to [Minepolz320](https://github.com/Minepolz320) for the original idea.
