### PR TITLE
Register TF Saplings Individually

### DIFF
--- a/src/main/java/twilightforest/item/TFRecipes.java
+++ b/src/main/java/twilightforest/item/TFRecipes.java
@@ -24,7 +24,7 @@ public class TFRecipes {
         // ore dictionary
         OreDictionary.registerOre("logWood", new ItemStack(TFBlocks.log, 1, OreDictionary.WILDCARD_VALUE));
         OreDictionary.registerOre("logWood", new ItemStack(TFBlocks.magicLog, 1, OreDictionary.WILDCARD_VALUE));
-        OreDictionary.registerOre("treeSapling", new ItemStack(TFBlocks.sapling, 1, OreDictionary.WILDCARD_VALUE));
+        for (int i = 0; i < 10; i++) OreDictionary.registerOre("treeSapling", new ItemStack(TFBlocks.sapling, 1, i));
         OreDictionary.registerOre("treeLeaves", new ItemStack(TFBlocks.leaves, 1, OreDictionary.WILDCARD_VALUE));
         OreDictionary.registerOre("treeLeaves", new ItemStack(TFBlocks.magicLeaves, 1, OreDictionary.WILDCARD_VALUE));
         OreDictionary.registerOre("plankWood", new ItemStack(TFBlocks.towerWood, 1, OreDictionary.WILDCARD_VALUE));


### PR DESCRIPTION
Register TF Saplings oredict individually to fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15202 for twilight forest
This allows other mods to get all existing twilight forest saplings from the oredictionary instead of one sapling with invalid metadata