### PR TITLE
Disable ticon-tf compat in gtnh

### DIFF
--- a/src/main/java/twilightforest/TwilightForestMod.java
+++ b/src/main/java/twilightforest/TwilightForestMod.java
@@ -343,10 +343,11 @@ public class TwilightForestMod {
         }
 
         // Tinkers Construct integration
-        if (Loader.isModLoaded("TConstruct")) {
+        if (Loader.isModLoaded("TConstruct") && !Loader.isModLoaded("dreamcraft")) {
             TFTinkerConstructIntegration.registerTinkersConstructIntegration(evt);
         } else {
-            FMLLog.info("[TwilightForest] Did not find Tinkers Construct, did not load Tinkers Construct integration.");
+            FMLLog.info(
+                    "[TwilightForest] Did not find Tinkers Construct or detected GTNH, did not load Tinkers Construct integration.");
         }
 
         // Remove certain things from NEI


### PR DESCRIPTION
Most of this stuff doesnt really work with GTNH as these are also gt materials and thats where the compat should be. It's just very broken overall. Besides that, many of these things are already added TGregworks. We dont need 2 knight metal tough rods with different recipes.

This compat was added in https://github.com/GTNewHorizons/twilightforest/pull/39.

However, disabling it like this does not fix everything, there are also issues in that compat that will be a problem outside of gtnh. See https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15895 for some of them.