### PR TITLE
Fix anvil metadata

### DIFF
--- a/src/main/java/twilightforest/structures/darktower/ComponentTFDarkTowerMain.java
+++ b/src/main/java/twilightforest/structures/darktower/ComponentTFDarkTowerMain.java
@@ -1327,8 +1327,8 @@ public class ComponentTFDarkTowerMain extends ComponentTFDarkTowerWing {
         this.makeStonePillar(world, forgeDeco, 9, y, 17, getStairMeta(1 + rotation), rotation, sbb);
 
         // anvils
-        this.placeBlockRotated(world, Blocks.anvil, decoRNG.nextInt(16), 13, y + 2, 5, rotation, sbb);
-        this.placeBlockRotated(world, Blocks.anvil, decoRNG.nextInt(16), 13, y + 2, 13, rotation, sbb);
+        this.placeBlockRotated(world, Blocks.anvil, decoRNG.nextInt(3), 13, y + 2, 5, rotation, sbb);
+        this.placeBlockRotated(world, Blocks.anvil, decoRNG.nextInt(3), 13, y + 2, 13, rotation, sbb);
 
         // fire pit
         makeFirePit(world, forgeDeco, 6, y + 1, 12, rotation, sbb);


### PR DESCRIPTION
Fix for:
 * https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15850

Looks like the problem is that the original code was generating anvils with random metadata in [0, 15], but the only valid values are [0, 2].

Note that this will only fix newly generated anvils; already generated anvils in existing worlds will still be broken.