### PR TITLE
Fix charm of keeping crash

### DIFF
--- a/src/main/java/twilightforest/TFEventListener.java
+++ b/src/main/java/twilightforest/TFEventListener.java
@@ -494,7 +494,7 @@ public class TFEventListener {
     @SubscribeEvent
     public void livingDies(LivingDeathEvent event) {
         if (event.entityLiving instanceof EntityPlayer player
-                && !event.entityLiving.worldObj.getGameRules().getGameRuleBooleanValue("keepInventory")) {
+                && !player.worldObj.getGameRules().getGameRuleBooleanValue("keepInventory")) {
 
             // TODO: Add support for keeping Bauble slot items on all tiers
             if (TFBaublesIntegration.consumeBaublesItem(player, TFItems.charmOfKeeping3)
@@ -657,8 +657,8 @@ public class TFEventListener {
                         1.5F,
                         1.0F);
             }
-
             playerKeepsMap.remove(player.getCommandSenderName());
+            playerBaublesMap.remove(player.getCommandSenderName());
         }
     }
 


### PR DESCRIPTION
If a player dies with a charm of keeping and at least 1 thing in their baubles they will correctly keep their inventory but the baubles data never gets removed afterwards. This causes any subsequent death without a charm of keeping to result in a crash or continuous kick from a server until restarted.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16036