### PR TITLE
Adds config for TiC Integration

### DIFF
--- a/src/main/java/tconstruct/tools/TFToolEvents.java
+++ b/src/main/java/tconstruct/tools/TFToolEvents.java
@@ -39,6 +39,7 @@ import tconstruct.weaponry.ammo.ArrowAmmo;
 import tconstruct.weaponry.ammo.BoltAmmo;
 import tconstruct.weaponry.entity.ArrowEntity;
 import tconstruct.weaponry.entity.BoltEntity;
+import twilightforest.TwilightForestMod;
 import twilightforest.integration.TFTinkerConstructIntegration;
 import twilightforest.integration.TFTinkerConstructIntegration.MaterialID;
 import twilightforest.item.TFItems;
@@ -152,22 +153,15 @@ public class TFToolEvents {
     }
 
     private EnumChatFormatting colorFromID(int materialID) {
-        EnumChatFormatting cf;
-        switch (materialID) {
-            default:
-                cf = EnumChatFormatting.DARK_GRAY;
-                break;
-            case MaterialID.FieryMetal:
-                cf = EnumChatFormatting.GOLD;
-                break;
-            case MaterialID.Knightmetal:
-                cf = EnumChatFormatting.GREEN;
-                break;
-            case MaterialID.NagaScale:
-            case MaterialID.Steeleaf:
-                cf = EnumChatFormatting.DARK_GREEN;
-                break;
+        EnumChatFormatting cf = EnumChatFormatting.DARK_GRAY;
+
+        if (materialID == MaterialID.FieryMetal) cf = EnumChatFormatting.GOLD;
+        else if (materialID == MaterialID.Knightmetal) {
+            cf = EnumChatFormatting.GREEN;
+        } else if (materialID == MaterialID.NagaScale || materialID == MaterialID.Steeleaf) {
+            cf = EnumChatFormatting.DARK_GREEN;
         }
+
         return cf;
     }
 
@@ -265,6 +259,7 @@ public class TFToolEvents {
 
     @SubscribeEvent
     public void onEntityConstructing(EntityEvent.EntityConstructing event) {
+        if (!TwilightForestMod.enableTiCIntegration) return;
         if (event.entity instanceof EntityPlayer player && TFTPlayerStats.get(player) == null) {
             TFTPlayerStats.register(player);
         }
@@ -272,6 +267,7 @@ public class TFToolEvents {
 
     @SubscribeEvent
     public void onItemPickup(EntityItemPickupEvent event) {
+        if (!TwilightForestMod.enableTiCIntegration) return;
         Item item = event.item.getEntityItem().getItem();
         EntityPlayer player = event.entityPlayer;
         TFTPlayerStats stats = TFTPlayerStats.get(player);
@@ -294,6 +290,7 @@ public class TFToolEvents {
 
     @SubscribeEvent
     public void onCrafting(ItemCraftedEvent event) {
+        if (!TwilightForestMod.enableTiCIntegration) return;
         Item item = event.crafting.getItem();
         EntityPlayer player = event.player;
         TFTPlayerStats stats = TFTPlayerStats.get(player);

--- a/src/main/java/twilightforest/TwilightForestMod.java
+++ b/src/main/java/twilightforest/TwilightForestMod.java
@@ -97,6 +97,7 @@ public class TwilightForestMod {
     public static boolean isSkinportLoaded = false;
     public static boolean areBaublesLoaded = false;
     public static boolean isNeiLoaded = false;
+    public static boolean enableTiCIntegration = false;
 
     // performance
     public static float canopyCoverage;
@@ -343,11 +344,15 @@ public class TwilightForestMod {
         }
 
         // Tinkers Construct integration
-        if (Loader.isModLoaded("TConstruct") && !Loader.isModLoaded("dreamcraft")) {
-            TFTinkerConstructIntegration.registerTinkersConstructIntegration(evt);
+        if (enableTiCIntegration) {
+            if (Loader.isModLoaded("TConstruct") && !Loader.isModLoaded("dreamcraft")) {
+                TFTinkerConstructIntegration.registerTinkersConstructIntegration(evt);
+            } else {
+                FMLLog.info(
+                        "[TwilightForest] Did not find Tinkers Construct or detected GTNH, did not load Tinkers Construct integration.");
+            }
         } else {
-            FMLLog.info(
-                    "[TwilightForest] Did not find Tinkers Construct or detected GTNH, did not load Tinkers Construct integration.");
+            FMLLog.info("[TwilightForest] Tinkers Construct integration is disabled.");
         }
 
         // Remove certain things from NEI
@@ -970,7 +975,12 @@ public class TwilightForestMod {
                 "Performance",
                 "TwilightOakChance",
                 48).comment = "Chance that a chunk in the Twilight Forest will contain a twilight oak tree.  Higher numbers reduce the number of trees, increasing performance.";
-
+        enableTiCIntegration = configFile.get(Configuration.CATEGORY_GENERAL, "EnableTiConstructIntegration", true)
+                .getBoolean(true);
+        configFile.get(
+                Configuration.CATEGORY_GENERAL,
+                "EnableTiConstructIntegration",
+                true).comment = "Enable backport of 1.12.2 TiC integration including materials and modifiers.";
         // fixed values, don't even read the config
         idMobWildBoar = 177;
         idMobBighornSheep = 178;

--- a/src/main/java/twilightforest/TwilightForestMod.java
+++ b/src/main/java/twilightforest/TwilightForestMod.java
@@ -345,11 +345,11 @@ public class TwilightForestMod {
 
         // Tinkers Construct integration
         if (enableTiCIntegration) {
-            if (Loader.isModLoaded("TConstruct") && !Loader.isModLoaded("dreamcraft")) {
+            if (!Loader.isModLoaded("TConstruct")) FMLLog
+                    .info("[TwilightForest] Could not find Tinkers Construct. Skipping Tinkers Construct integration.");
+            else {
+                FMLLog.info("[TwilightForest] Tinkers Construct detected. Initiating Tinkers Construct integration.");
                 TFTinkerConstructIntegration.registerTinkersConstructIntegration(evt);
-            } else {
-                FMLLog.info(
-                        "[TwilightForest] Did not find Tinkers Construct or detected GTNH, did not load Tinkers Construct integration.");
             }
         } else {
             FMLLog.info("[TwilightForest] Tinkers Construct integration is disabled.");

--- a/src/main/java/twilightforest/TwilightForestMod.java
+++ b/src/main/java/twilightforest/TwilightForestMod.java
@@ -204,6 +204,11 @@ public class TwilightForestMod {
     public static int idBiomeFireSwamp;
     public static int idBiomeThornlands;
 
+    public static int FieryMetal_ID;
+    public static int Knightmetal_ID;
+    public static int NagaScale_ID;
+    public static int Steeleaf_ID;
+
     // used to report conflicts
     public static boolean hasBiomeIdConflicts = false;
     public static boolean hasAssignedBiomeID = false;
@@ -975,12 +980,21 @@ public class TwilightForestMod {
                 "Performance",
                 "TwilightOakChance",
                 48).comment = "Chance that a chunk in the Twilight Forest will contain a twilight oak tree.  Higher numbers reduce the number of trees, increasing performance.";
-        enableTiCIntegration = configFile.get(Configuration.CATEGORY_GENERAL, "EnableTiConstructIntegration", true)
+        enableTiCIntegration = configFile.get("Tinker Integration", "EnableTiConstructIntegration", true)
                 .getBoolean(true);
         configFile.get(
-                Configuration.CATEGORY_GENERAL,
+                "Tinker Integration",
                 "EnableTiConstructIntegration",
                 true).comment = "Enable backport of 1.12.2 TiC integration including materials and modifiers.";
+        FieryMetal_ID = configFile.get("Tinker Integration", "FieryMetal_ID", 42).getInt(42);
+        configFile.get("Tinker Integration", "FieryMetal_ID", 42).comment = "Tinker Material ID for FieryMetal.";
+        Knightmetal_ID = configFile.get("Tinker Integration", "KnightMetal_ID", 43).getInt(43);
+        configFile.get("Tinker Integration", "KnightMetal_ID", 43).comment = "Tinker Material ID for KnightMetal.";
+        NagaScale_ID = configFile.get("Tinker Integration", "NagaScale_ID", 44).getInt(44);
+        configFile.get("Tinker Integration", "NagaScale_ID", 44).comment = "Tinker Material ID for NagaScale.";
+        Steeleaf_ID = configFile.get("Tinker Integration", "Steeleaf_ID", 45).getInt(45);
+        configFile.get("Tinker Integration", "Steeleaf_ID", 45).comment = "Tinker Material ID for Steeleaf.";
+
         // fixed values, don't even read the config
         idMobWildBoar = 177;
         idMobBighornSheep = 178;

--- a/src/main/java/twilightforest/integration/TFTinkerConstructIntegration.java
+++ b/src/main/java/twilightforest/integration/TFTinkerConstructIntegration.java
@@ -56,6 +56,7 @@ import tconstruct.tools.items.TFMaterialItem;
 import tconstruct.util.Reference;
 import tconstruct.util.config.PHConstruct;
 import tconstruct.weaponry.TinkerWeaponry;
+import twilightforest.TwilightForestMod;
 import twilightforest.block.TFBlocks;
 import twilightforest.item.TFItems;
 
@@ -80,10 +81,10 @@ public class TFTinkerConstructIntegration {
 
     public static final class MaterialID {
 
-        public static final int FieryMetal = 42;
-        public static final int Knightmetal = 43;
-        public static final int NagaScale = 44;
-        public static final int Steeleaf = 45;
+        public static final int FieryMetal = TwilightForestMod.FieryMetal_ID;
+        public static final int Knightmetal = TwilightForestMod.Knightmetal_ID;
+        public static final int NagaScale = TwilightForestMod.NagaScale_ID;
+        public static final int Steeleaf = TwilightForestMod.Steeleaf_ID;
     }
 
     public static void registerTinkersConstructIntegration(FMLPostInitializationEvent evt) {


### PR DESCRIPTION
Allow disabling of  [#39](https://github.com/GTNewHorizons/twilightforest/pull/39) using configs:
```
   # Enable backport of 1.12.2 TiC integration including materials and modifiers [Default: true].
    B:EnableTiConstructIntegration=true
```