### PR TITLE
InfusionStabiliser update

### DIFF
--- a/src/main/java/twilightforest/block/BlockTFFireflyJar.java
+++ b/src/main/java/twilightforest/block/BlockTFFireflyJar.java
@@ -13,16 +13,13 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import thaumcraft.api.crafting.IInfusionStabiliser;
 import twilightforest.TwilightForestMod;
 import twilightforest.entity.passive.EntityTFTinyFirefly;
 import twilightforest.item.TFItems;
 
-@Optional.Interface(iface = "thaumcraft.api.crafting.IInfusionStabiliser", modid = "Thaumcraft")
-public class BlockTFFireflyJar extends Block implements IInfusionStabiliser {
+public class BlockTFFireflyJar extends Block {
 
     public static IIcon jarTop;
     public static IIcon jarSide;
@@ -150,11 +147,6 @@ public class BlockTFFireflyJar extends Block implements IInfusionStabiliser {
         BlockTFFireflyJar.jarTop = par1IconRegister.registerIcon(TwilightForestMod.ID + ":fireflyjar_top");
         BlockTFFireflyJar.jarSide = par1IconRegister.registerIcon(TwilightForestMod.ID + ":fireflyjar_side");
         BlockTFFireflyJar.jarCork = par1IconRegister.registerIcon(TwilightForestMod.ID + ":fireflyjar_cork");
-    }
-
-    @Override
-    public boolean canStabaliseInfusion(World world, int x, int y, int z) {
-        return true;
     }
 
 }

--- a/src/main/java/twilightforest/block/BlockTFFireflyJar.java
+++ b/src/main/java/twilightforest/block/BlockTFFireflyJar.java
@@ -13,13 +13,16 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.crafting.IInfusionStabiliser;
 import twilightforest.TwilightForestMod;
 import twilightforest.entity.passive.EntityTFTinyFirefly;
 import twilightforest.item.TFItems;
 
-public class BlockTFFireflyJar extends Block {
+@Optional.Interface(iface = "thaumcraft.api.crafting.IInfusionStabiliser", modid = "Thaumcraft")
+public class BlockTFFireflyJar extends Block implements IInfusionStabiliser {
 
     public static IIcon jarTop;
     public static IIcon jarSide;
@@ -147,6 +150,11 @@ public class BlockTFFireflyJar extends Block {
         BlockTFFireflyJar.jarTop = par1IconRegister.registerIcon(TwilightForestMod.ID + ":fireflyjar_top");
         BlockTFFireflyJar.jarSide = par1IconRegister.registerIcon(TwilightForestMod.ID + ":fireflyjar_side");
         BlockTFFireflyJar.jarCork = par1IconRegister.registerIcon(TwilightForestMod.ID + ":fireflyjar_cork");
+    }
+
+    @Override
+    public boolean canStabaliseInfusion(World world, int x, int y, int z) {
+        return true;
     }
 
 }

--- a/src/main/java/twilightforest/block/BlockTFTrophy.java
+++ b/src/main/java/twilightforest/block/BlockTFTrophy.java
@@ -19,8 +19,10 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.crafting.IInfusionStabiliser;
 import twilightforest.item.TFItems;
 import twilightforest.tileentity.TileEntityTFTrophy;
 
@@ -28,7 +30,8 @@ import twilightforest.tileentity.TileEntityTFTrophy;
  * Head trophy similar to (and based partially on) BlockSkull
  *
  */
-public class BlockTFTrophy extends BlockContainer {
+@Optional.Interface(iface = "thaumcraft.api.crafting.IInfusionStabiliser", modid = "Thaumcraft")
+public class BlockTFTrophy extends BlockContainer implements IInfusionStabiliser {
 
     public BlockTFTrophy() {
         super(Material.circuits);
@@ -210,6 +213,11 @@ public class BlockTFTrophy extends BlockContainer {
     @SideOnly(Side.CLIENT)
     public void registerBlockIcons(IIconRegister par1IconRegister) {
         // don't load anything
+    }
+
+    @Override
+    public boolean canStabaliseInfusion(World world, int x, int y, int z) {
+        return true;
     }
 
 }

--- a/src/main/java/twilightforest/block/BlockTFTrophyPedestal.java
+++ b/src/main/java/twilightforest/block/BlockTFTrophyPedestal.java
@@ -23,13 +23,16 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import thaumcraft.api.crafting.IInfusionStabiliser;
 import twilightforest.TFAchievementPage;
 import twilightforest.TwilightForestMod;
 import twilightforest.item.TFItems;
 
-public class BlockTFTrophyPedestal extends Block {
+@Optional.Interface(iface = "thaumcraft.api.crafting.IInfusionStabiliser", modid = "Thaumcraft")
+public class BlockTFTrophyPedestal extends Block implements IInfusionStabiliser {
 
     private IIcon sprTopActive;
     private IIcon sprTop;
@@ -361,6 +364,11 @@ public class BlockTFTrophyPedestal extends Block {
         } else {
             return super.getPlayerRelativeBlockHardness(par1EntityPlayer, world, x, y, z);
         }
+    }
+
+    @Override
+    public boolean canStabaliseInfusion(World world, int x, int y, int z) {
+        return true;
     }
 
 }


### PR DESCRIPTION
Backport https://github.com/TeamTwilight/twilightforest/commit/c9d8836e44262f02188aab000f565509f8584621

Now FireflyJar, Trophy & TrophyPedestal will be considered as Infusion Stabiliser 

![2024-06-20_22 59 53](https://github.com/GTNewHorizons/twilightforest/assets/17870449/6987db6c-7f9a-4fbd-b2ea-717df74520a1)
