### PR TITLE
Fix Twilight Lich NEI drops + modpack loading speed

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:Battlegear2:1.4.0:api") {} //For TiC to work
     compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.6.14-GTNH:dev")
     compileOnly("curse.maven:skinport-234948:3212017")
-    compileOnly("com.github.GTNewHorizons:Mobs-Info:0.4.0-GTNH:dev")
+    compileOnly("com.github.GTNewHorizons:Mobs-Info:0.4.1-GTNH:dev")
 
     // For Thaumcraft runtime
     compileOnly ("com.github.GTNewHorizons:Baubles:1.0.4:dev")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:Battlegear2:1.4.0:api") {} //For TiC to work
     compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.6.14-GTNH:dev")
     compileOnly("curse.maven:skinport-234948:3212017")
-    compileOnly("com.github.GTNewHorizons:Mobs-Info:0.3.4-GTNH-pre:dev")
+    compileOnly("com.github.GTNewHorizons:Mobs-Info:0.3.5-GTNH-pre:dev")
 
     // For Thaumcraft runtime
     compileOnly ("com.github.GTNewHorizons:Baubles:1.0.4:dev")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,6 +6,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:Battlegear2:1.4.0:api") {} //For TiC to work
     compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.6.14-GTNH:dev")
     compileOnly("curse.maven:skinport-234948:3212017")
+    compileOnly("com.github.GTNewHorizons:Mobs-Info:0.3.4-GTNH-pre:dev")
 
     // For Thaumcraft runtime
     compileOnly ("com.github.GTNewHorizons:Baubles:1.0.4:dev")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:Battlegear2:1.4.0:api") {} //For TiC to work
     compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.6.14-GTNH:dev")
     compileOnly("curse.maven:skinport-234948:3212017")
-    compileOnly("com.github.GTNewHorizons:Mobs-Info:0.3.5-GTNH-pre:dev")
+    compileOnly("com.github.GTNewHorizons:Mobs-Info:0.4.0-GTNH:dev")
 
     // For Thaumcraft runtime
     compileOnly ("com.github.GTNewHorizons:Baubles:1.0.4:dev")

--- a/src/main/java/twilightforest/entity/boss/EntityTFLich.java
+++ b/src/main/java/twilightforest/entity/boss/EntityTFLich.java
@@ -156,88 +156,36 @@ public class EntityTFLich extends EntityMob implements IBossDisplayData, IMobInf
     @Override
     public void provideDropsInformation(@Nonnull ArrayList<MobDrop> drops) {
         // scepter
-        drops.add(
-                new MobDrop(
-                        new ItemStack(TFItems.scepterZombie),
-                        MobDrop.DropType.Normal,
-                        3333,
-                        null,
-                        null,
-                        false,
-                        false));
-        drops.add(
-                new MobDrop(
-                        new ItemStack(TFItems.scepterLifeDrain),
-                        MobDrop.DropType.Normal,
-                        3333,
-                        null,
-                        null,
-                        false,
-                        false));
-        drops.add(
-                new MobDrop(
-                        new ItemStack(TFItems.scepterTwilight),
-                        MobDrop.DropType.Normal,
-                        3333,
-                        null,
-                        null,
-                        false,
-                        false));
+        drops.add(MobDrop.create(new ItemStack(TFItems.scepterZombie)).withChance(0.3333d));
+        drops.add(MobDrop.create(new ItemStack(TFItems.scepterLifeDrain)).withChance(0.3333d));
+        drops.add(MobDrop.create(new ItemStack(TFItems.scepterTwilight)).withChance(0.3333d));
         // gold thing
-        int chance = (int) ((MobDrop.getChanceBasedOnFromTo(2, 4) / 5d) * 10000d);
+        double chance = MobDrop.getChanceBasedOnFromTo(2, 4) / 5d;
         drops.add(
-                new MobDrop(new ItemStack(Items.golden_sword), MobDrop.DropType.Normal, chance, 25, null, true, false));
+                MobDrop.create(new ItemStack(Items.golden_sword)).withChance(chance).withRandomEnchant(25)
+                        .withLooting());
         drops.add(
-                new MobDrop(
-                        new ItemStack(Items.golden_helmet),
-                        MobDrop.DropType.Normal,
-                        chance,
-                        25,
-                        null,
-                        true,
-                        false));
+                MobDrop.create(new ItemStack(Items.golden_helmet)).withChance(chance).withRandomEnchant(25)
+                        .withLooting());
         drops.add(
-                new MobDrop(
-                        new ItemStack(Items.golden_chestplate),
-                        MobDrop.DropType.Normal,
-                        chance,
-                        25,
-                        null,
-                        true,
-                        false));
+                MobDrop.create(new ItemStack(Items.golden_chestplate)).withChance(chance).withRandomEnchant(25)
+                        .withLooting());
         drops.add(
-                new MobDrop(
-                        new ItemStack(Items.golden_leggings),
-                        MobDrop.DropType.Normal,
-                        chance,
-                        25,
-                        null,
-                        true,
-                        false));
+                MobDrop.create(new ItemStack(Items.golden_leggings)).withChance(chance).withRandomEnchant(25)
+                        .withLooting());
         drops.add(
-                new MobDrop(new ItemStack(Items.golden_boots), MobDrop.DropType.Normal, chance, 25, null, true, false));
+                MobDrop.create(new ItemStack(Items.golden_boots)).withChance(chance).withRandomEnchant(25)
+                        .withLooting());
         // ender pearl
         drops.add(
-                new MobDrop(
-                        new ItemStack(Items.ender_pearl),
-                        MobDrop.DropType.Normal,
-                        (int) (MobDrop.getChanceBasedOnFromTo(1, 4) * 10000d),
-                        null,
-                        null,
-                        true,
-                        false));
+                MobDrop.create(new ItemStack(Items.ender_pearl)).withChance(MobDrop.getChanceBasedOnFromTo(1, 4))
+                        .withLooting());
         // bones
         drops.add(
-                new MobDrop(
-                        new ItemStack(Items.bone),
-                        MobDrop.DropType.Normal,
-                        (int) (MobDrop.getChanceBasedOnFromTo(5, 9) * 10000d),
-                        null,
-                        null,
-                        true,
-                        false));
+                MobDrop.create(new ItemStack(Items.bone)).withChance(MobDrop.getChanceBasedOnFromTo(5, 9))
+                        .withLooting());
         // trophy
-        drops.add(new MobDrop(new ItemStack(TFItems.trophy), MobDrop.DropType.Normal, 10000, null, null, true, false));
+        drops.add(MobDrop.create(new ItemStack(TFItems.trophy, 1, 2)));
     }
 
     private void dropScepter() {

--- a/src/main/java/twilightforest/entity/boss/EntityTFLich.java
+++ b/src/main/java/twilightforest/entity/boss/EntityTFLich.java
@@ -1,6 +1,9 @@
 package twilightforest.entity.boss;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import javax.annotation.Nonnull;
 
 import net.minecraft.block.Block;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -30,6 +33,10 @@ import net.minecraft.util.Vec3;
 import net.minecraft.world.EnumDifficulty;
 import net.minecraft.world.World;
 
+import com.kuba6000.mobsinfo.api.IMobInfoProvider;
+import com.kuba6000.mobsinfo.api.MobDrop;
+
+import cpw.mods.fml.common.Optional;
 import twilightforest.TFAchievementPage;
 import twilightforest.TFFeature;
 import twilightforest.TwilightForestMod;
@@ -40,7 +47,8 @@ import twilightforest.world.ChunkProviderTwilightForest;
 import twilightforest.world.TFWorldChunkManager;
 import twilightforest.world.WorldProviderTwilightForest;
 
-public class EntityTFLich extends EntityMob implements IBossDisplayData {
+@Optional.Interface(iface = "com.kuba6000.mobsinfo.api.IMobInfoProvider", modid = "mobsinfo")
+public class EntityTFLich extends EntityMob implements IBossDisplayData, IMobInfoProvider {
 
     private static final int DATA_ISCLONE = 21;
     private static final int DATA_SHIELDSTRENGTH = 17;
@@ -121,6 +129,7 @@ public class EntityTFLich extends EntityMob implements IBossDisplayData {
 
     @Override
     protected void dropFewItems(boolean par1, int par2) {
+        // EVERY CHANGE MADE IN HERE MUST BE ALSO MADE IN provideDropsInformation
         dropScepter();
 
         int totalDrops = this.rand.nextInt(3 + par2) + 2;
@@ -141,6 +150,94 @@ public class EntityTFLich extends EntityMob implements IBossDisplayData {
 
         // trophy
         this.entityDropItem(new ItemStack(TFItems.trophy, 1, 2), 0);
+    }
+
+    @Optional.Method(modid = "mobsinfo")
+    @Override
+    public void provideDropsInformation(@Nonnull ArrayList<MobDrop> drops) {
+        // scepter
+        drops.add(
+                new MobDrop(
+                        new ItemStack(TFItems.scepterZombie),
+                        MobDrop.DropType.Normal,
+                        3333,
+                        null,
+                        null,
+                        false,
+                        false));
+        drops.add(
+                new MobDrop(
+                        new ItemStack(TFItems.scepterLifeDrain),
+                        MobDrop.DropType.Normal,
+                        3333,
+                        null,
+                        null,
+                        false,
+                        false));
+        drops.add(
+                new MobDrop(
+                        new ItemStack(TFItems.scepterTwilight),
+                        MobDrop.DropType.Normal,
+                        3333,
+                        null,
+                        null,
+                        false,
+                        false));
+        // gold thing
+        int chance = (int) ((MobDrop.getChanceBasedOnFromTo(2, 4) / 5d) * 10000d);
+        drops.add(
+                new MobDrop(new ItemStack(Items.golden_sword), MobDrop.DropType.Normal, chance, 25, null, true, false));
+        drops.add(
+                new MobDrop(
+                        new ItemStack(Items.golden_helmet),
+                        MobDrop.DropType.Normal,
+                        chance,
+                        25,
+                        null,
+                        true,
+                        false));
+        drops.add(
+                new MobDrop(
+                        new ItemStack(Items.golden_chestplate),
+                        MobDrop.DropType.Normal,
+                        chance,
+                        25,
+                        null,
+                        true,
+                        false));
+        drops.add(
+                new MobDrop(
+                        new ItemStack(Items.golden_leggings),
+                        MobDrop.DropType.Normal,
+                        chance,
+                        25,
+                        null,
+                        true,
+                        false));
+        drops.add(
+                new MobDrop(new ItemStack(Items.golden_boots), MobDrop.DropType.Normal, chance, 25, null, true, false));
+        // ender pearl
+        drops.add(
+                new MobDrop(
+                        new ItemStack(Items.ender_pearl),
+                        MobDrop.DropType.Normal,
+                        (int) (MobDrop.getChanceBasedOnFromTo(1, 4) * 10000d),
+                        null,
+                        null,
+                        true,
+                        false));
+        // bones
+        drops.add(
+                new MobDrop(
+                        new ItemStack(Items.bone),
+                        MobDrop.DropType.Normal,
+                        (int) (MobDrop.getChanceBasedOnFromTo(5, 9) * 10000d),
+                        null,
+                        null,
+                        true,
+                        false));
+        // trophy
+        drops.add(new MobDrop(new ItemStack(TFItems.trophy), MobDrop.DropType.Normal, 10000, null, null, true, false));
     }
 
     private void dropScepter() {
@@ -1101,5 +1198,4 @@ public class EntityTFLich extends EntityMob implements IBossDisplayData {
     public EnumCreatureAttribute getCreatureAttribute() {
         return EnumCreatureAttribute.UNDEAD;
     }
-
 }


### PR DESCRIPTION
issue:
[23:08:35] [Client thread/WARN] [mobsinfo[Mob Recipe Loader]/mobsinfo]: TwilightForest.Twilight Lich normal dropmap took too long, skipping
[23:08:45] [Client thread/WARN] [mobsinfo[Mob Recipe Loader]/mobsinfo]: TwilightForest.Twilight Lich normal dropmap took too long, skipping
[23:08:45] [Client thread/INFO] [mobsinfo[Mob Recipe Loader]/mobsinfo]: Entity TwilightForest.Twilight Lich took 20.001878999s in total

![image](https://github.com/user-attachments/assets/173d033e-783e-42dc-9d25-b8c152ec21ae)
