### PR TITLE
Don't leak player inventory map

### DIFF
--- a/src/main/java/twilightforest/TFEventListener.java
+++ b/src/main/java/twilightforest/TFEventListener.java
@@ -85,6 +85,11 @@ public class TFEventListener {
     private int amountOfCobbleToReplace = 0;
     private long lastSpawnedHintMonsterTime;
 
+    public void clearCaches() {
+        playerKeepsMap.clear();
+        playerBaublesMap.clear();
+    }
+
     /**
      * Check if the player picks up a lich scepter, and if so, check for the scepter mastery achievement
      */

--- a/src/main/java/twilightforest/TFPlayerHandler.java
+++ b/src/main/java/twilightforest/TFPlayerHandler.java
@@ -24,6 +24,10 @@ public class TFPlayerHandler {
         TFBaublesIntegration.clearPlayerMap(player);
     }
 
+    public static void clearCaches() {
+        playerKeepsMap.clear();
+    }
+
     public static InventoryPlayer getPlayerKeepInventory(EntityPlayer player) {
         if (!playerKeepsMap.containsKey(player.getCommandSenderName())) {
             InventoryPlayer inventory = new InventoryPlayer(player);

--- a/src/main/java/twilightforest/TwilightForestMod.java
+++ b/src/main/java/twilightforest/TwilightForestMod.java
@@ -24,6 +24,7 @@ import cpw.mods.fml.common.event.FMLMissingMappingsEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
+import cpw.mods.fml.common.event.FMLServerStoppingEvent;
 import cpw.mods.fml.common.network.FMLEventChannel;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.registry.EntityRegistry;
@@ -31,6 +32,7 @@ import cpw.mods.fml.common.registry.GameRegistry;
 import twilightforest.biomes.TFBiomeBase;
 import twilightforest.block.TFBlocks;
 import twilightforest.entity.TFCreatures;
+import twilightforest.integration.TFBaublesIntegration;
 import twilightforest.integration.TFNeiIntegration;
 import twilightforest.integration.TFThaumcraftIntegration;
 import twilightforest.integration.TFTinkerConstructIntegration;
@@ -226,6 +228,8 @@ public class TwilightForestMod {
     @SidedProxy(clientSide = "twilightforest.client.TFClientProxy", serverSide = "twilightforest.TFCommonProxy")
     public static TFCommonProxy proxy;
 
+    final TFEventListener eventListener = new TFEventListener();
+
     public TwilightForestMod() {
         TwilightForestMod.instance = this;
     }
@@ -288,7 +292,6 @@ public class TwilightForestMod {
         NetworkRegistry.INSTANCE.registerGuiHandler(instance, proxy);
 
         // event listener, for those events that seem worth listening to
-        final TFEventListener eventListener = new TFEventListener();
         MinecraftForge.EVENT_BUS.register(eventListener);
         FMLCommonHandler.instance().bus().register(eventListener); // we're getting events off this bus too
 
@@ -399,6 +402,13 @@ public class TwilightForestMod {
 
         // event.registerServerCommand(new CommandTFFeature());
         event.registerServerCommand(new CommandTFProgress());
+    }
+
+    @EventHandler
+    public void stopServer(FMLServerStoppingEvent event) {
+        TFPlayerHandler.clearCaches();
+        TFBaublesIntegration.playerBaublesMap.clear();
+        eventListener.clearCaches();
     }
 
     @EventHandler


### PR DESCRIPTION
The cache should probably be cleared when the world closes, otherwise it remains valid when a new world is loaded in SP.