### PR TITLE
Fix an incorrect asset path for the mob.yeti.pant sound

### DIFF
--- a/src/main/resources/assets/twilightforest/sounds.json
+++ b/src/main/resources/assets/twilightforest/sounds.json
@@ -271,7 +271,7 @@
     "sounds": [
       "mob/yeti/pant1",
       "mob/yeti/pant2",
-      "mob/yeti/pant"
+      "mob/yeti/pant3"
     ]
   },
     "random.slider": {


### PR DESCRIPTION
Fixes a typo in the sounds.json file, which was referencing a non-existent asset. I assume it was meant to reference `pant3.ogg`, which went unused until now.