### PR TITLE
Set default filler block meta to 0 for TFBiomeBase

### DIFF
--- a/src/main/java/twilightforest/biomes/TFBiomeBase.java
+++ b/src/main/java/twilightforest/biomes/TFBiomeBase.java
@@ -97,6 +97,9 @@ public abstract class TFBiomeBase extends BiomeGenBase {
     public TFBiomeBase(int i) {
         super(i);
 
+        // Set default filler block meta to 0
+        this.field_76754_C = 0;
+
         bigMushroomGen = new WorldGenBigMushroom();
         birchGen = new WorldGenForest(false, false);
 
@@ -136,6 +139,7 @@ public abstract class TFBiomeBase extends BiomeGenBase {
 
         getTFBiomeDecorator().setTreesPerChunk(10);
         getTFBiomeDecorator().setGrassPerChunk(2);
+
     }
 
     @Override


### PR DESCRIPTION
I'm not actually sure what the field_76754_C field does. Its from vanilla but I can't seem to find any actual uses of it in vanilla. The default value seems to be 5169201 as well. In TF its used as the meta for the filler block which would result in dirt having meta of 49. Both the final plateau and thornlands, which change this value, still have the correct filler block generating after this change.

Closes https://github.com/GTNewHorizons/twilightforest/issues/57
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24206