### PR TITLE
Fix IntCache memory leak

### DIFF
--- a/src/main/java/twilightforest/world/TFWorldChunkManager.java
+++ b/src/main/java/twilightforest/world/TFWorldChunkManager.java
@@ -192,6 +192,7 @@ public class TFWorldChunkManager extends WorldChunkManager {
      */
     @SuppressWarnings("rawtypes")
     public boolean areBiomesViable(int par1, int par2, int par3, List par4List) {
+        IntCache.resetIntCache();
         int i = par1 - par3 >> 2;
         int j = par2 - par3 >> 2;
         int k = par1 + par3 >> 2;
@@ -216,6 +217,7 @@ public class TFWorldChunkManager extends WorldChunkManager {
      */
     @SuppressWarnings("rawtypes")
     public ChunkPosition findBiomePosition(int par1, int par2, int par3, List par4List, Random par5Random) {
+        IntCache.resetIntCache();
         int i = par1 - par3 >> 2;
         int j = par2 - par3 >> 2;
         int k = par1 + par3 >> 2;


### PR DESCRIPTION
should fix : https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/22708

This mod didn't call `IntCache.resetIntCache();` in certain generation methods which causes the intcache to grow bigger and bigger and bigger until your game OOM.
This can be easily verified by using this PR https://github.com/GTNewHorizons/Hodgepodge/pull/868

and then you go back and forth in the twilight portal and every time you cross the portal the intcache size get bigger.